### PR TITLE
Don't use random magic number for id in tests

### DIFF
--- a/src/tests/controllers/Brand.test.ts
+++ b/src/tests/controllers/Brand.test.ts
@@ -1,6 +1,6 @@
 import * as chai from 'chai';
 import chaiHttp = require('chai-http');
-import {app, brands, jwtToken} from '../setup';
+import { app, brands, jwtToken } from '../setup';
 import { Brand } from '@entities/Brand';
 
 chai.use(chaiHttp);
@@ -9,12 +9,18 @@ const expect = chai.expect;
 
 describe('BrandController GET', () => {
   it('Should respond with 200', async () => {
-    const res = await chai.request(app).get('/brands').set('Authorization', jwtToken);;
+    const res = await chai
+      .request(app)
+      .get('/brands')
+      .set('Authorization', jwtToken);
     expect(res).to.have.status(200);
   });
 
   it('Should return existing stores', async () => {
-    const res = await chai.request(app).get('/brands').set('Authorization', jwtToken);;
+    const res = await chai
+      .request(app)
+      .get('/brands')
+      .set('Authorization', jwtToken);
     expect(res).to.be.json;
     expect(res.body).to.have.length.above(0);
     expect(res.body).to.have.length(brands.length);
@@ -32,9 +38,13 @@ describe('BrandController Post', () => {
     let res = await chai
       .request(app)
       .post('/brands/')
-      .send(brand).set('Authorization', jwtToken);
+      .send(brand)
+      .set('Authorization', jwtToken);
     expect(res).to.have.status(201);
-    res = await chai.request(app).get('/brands/').set('Authorization', jwtToken);;
+    res = await chai
+      .request(app)
+      .get('/brands/')
+      .set('Authorization', jwtToken);
     expect(res.body.length).to.be.equal(brands.length + 1);
   });
 });
@@ -42,14 +52,23 @@ describe('BrandController Post', () => {
 describe('BrandController DELETE', () => {
   it('Should delete one Brand', async () => {
     const id = brands[3].id;
-    let res = await chai.request(app).delete(`/brands/${id}`).set('Authorization', jwtToken);
+    let res = await chai
+      .request(app)
+      .delete(`/brands/${id}`)
+      .set('Authorization', jwtToken);
     expect(res).to.have.status(200);
-    res = await chai.request(app).get('/brands/').set('Authorization', jwtToken);
+    res = await chai
+      .request(app)
+      .get('/brands/')
+      .set('Authorization', jwtToken);
     expect(res.body.length).to.be.equal(brands.length - 1);
   });
 
   it('Should not find the desired Brand', async () => {
-    const res = await chai.request(app).delete('/brands/1000').set('Authorization', jwtToken);
+    const res = await chai
+      .request(app)
+      .delete('/brands/-1')
+      .set('Authorization', jwtToken);
     expect(res).to.have.status(404);
   });
 });

--- a/src/tests/controllers/ListProduct.test.ts
+++ b/src/tests/controllers/ListProduct.test.ts
@@ -1,6 +1,6 @@
 import * as chai from 'chai';
 import chaiHttp = require('chai-http');
-import {app, jwtToken, listProduct} from '../setup';
+import { app, jwtToken, listProduct } from '../setup';
 import { getRepository } from 'typeorm';
 import { ListProduct } from '@entities/ListProduct';
 
@@ -10,12 +10,18 @@ const expect = chai.expect;
 
 describe('ListProductController GET', () => {
   it('Should respond with 200', async () => {
-    const res = await chai.request(app).get('/listProduct').set('Authorization', jwtToken);
+    const res = await chai
+      .request(app)
+      .get('/listProduct')
+      .set('Authorization', jwtToken);
     expect(res).to.have.status(200);
   });
 
   it('Should return existing listProduct', async () => {
-    const res = await chai.request(app).get('/listProduct').set('Authorization', jwtToken);
+    const res = await chai
+      .request(app)
+      .get('/listProduct')
+      .set('Authorization', jwtToken);
     expect(res).to.be.json;
     expect(res.body).to.have.length.above(0);
     expect(res.body).to.have.length(listProduct.length);
@@ -27,8 +33,10 @@ describe('ListProductController GET', () => {
   it('should return existing listProduct from specific list', async () => {
     const id = listProduct[0].listId;
     const productListFromList = listProduct.filter(l => l.listId === id);
-    const res = await chai.request(app).get(`/listproduct/fromlist/${id}`)
-        .set('Authorization', jwtToken);
+    const res = await chai
+      .request(app)
+      .get(`/listproduct/fromlist/${id}`)
+      .set('Authorization', jwtToken);
     expect(res).to.be.json;
     expect(res.body).to.have.length.above(0);
     expect(res.body).to.have.length(productListFromList.length);
@@ -41,16 +49,23 @@ describe('ListProductController GET', () => {
 describe('ListProductController DELETE Then POST', () => {
   it('Should delete the 1 listProduct', async () => {
     const id = listProduct[0].id;
-    let res = await chai.request(app).delete(`/listProduct/${id}`)
-        .set('Authorization', jwtToken);
+    let res = await chai
+      .request(app)
+      .delete(`/listProduct/${id}`)
+      .set('Authorization', jwtToken);
     expect(res).to.have.status(200);
-    res = await chai.request(app).get('/listProduct/').set('Authorization', jwtToken);
+    res = await chai
+      .request(app)
+      .get('/listProduct/')
+      .set('Authorization', jwtToken);
     expect(res.body.length).to.be.equal(listProduct.length - 1);
   });
 
   it('Should not find the desired listProduct', async () => {
-    const res = await chai.request(app).delete('/listProduct/1000')
-        .set('Authorization', jwtToken);
+    const res = await chai
+      .request(app)
+      .delete('/listProduct/-1')
+      .set('Authorization', jwtToken);
     expect(res).to.have.status(404);
   });
 });
@@ -67,9 +82,13 @@ describe('ListProductController Post', () => {
     let res = await chai
       .request(app)
       .post('/listProduct/')
-      .send(list).set('Authorization', jwtToken);
+      .send(list)
+      .set('Authorization', jwtToken);
     expect(res).to.have.status(201);
-    res = await chai.request(app).get('/listProduct/').set('Authorization', jwtToken);
+    res = await chai
+      .request(app)
+      .get('/listProduct/')
+      .set('Authorization', jwtToken);
     expect(res.body.length).to.be.equal(listProduct.length);
   });
 });

--- a/src/tests/controllers/Promotion.test.ts
+++ b/src/tests/controllers/Promotion.test.ts
@@ -54,15 +54,16 @@ describe('PromotionController should be able to list items', () => {
 
 describe('PromotionController update a promotion', () => {
   it('Should update the first promotion', async () => {
+    const id = promotions[0].id;
     let res = await chai
       .request(app)
-      .patch('/promotions/1')
+      .patch(`/promotions/${id}`)
       .send({ description: 'toto' })
       .set('Authorization', jwtToken);
     expect(res).to.have.status(200);
     res = await chai
       .request(app)
-      .get('/promotions/1')
+      .get(`/promotions/${id}`)
       .set('Authorization', jwtToken);
     expect(res.body.description).to.be.equal('toto');
   });
@@ -99,9 +100,10 @@ describe('PromotionController post a promotion', () => {
 
 describe('PromotionController delete a promotion', () => {
   it('Should delete a promotion', async () => {
+    const id = promotions[1].id;
     let res = await chai
       .request(app)
-      .delete('/promotions/2')
+      .delete(`/promotions/${id}`)
       .set('Authorization', jwtToken);
     expect(res).to.have.status(200);
     res = await chai
@@ -114,7 +116,7 @@ describe('PromotionController delete a promotion', () => {
   it('Should not find the desired promotion', async () => {
     const res = await chai
       .request(app)
-      .delete('/promotions/10000')
+      .delete('/promotions/-1')
       .set('Authorization', jwtToken);
     expect(res).to.have.status(404);
   });

--- a/src/tests/controllers/Store.test.ts
+++ b/src/tests/controllers/Store.test.ts
@@ -113,19 +113,20 @@ describe('storeController get Relevant Store', () => {
 
 describe('StoreController UPDATE', () => {
   it('Should update the 2 store position', async () => {
+    const id = stores[1].id;
     const position = {
       type: 'Point',
       coordinates: [-48.23456, 20.12345],
     };
     let res = await chai
       .request(app)
-      .patch('/stores/2')
+      .patch(`/stores/${id}`)
       .send({ position })
       .set('Authorization', jwtToken);
     expect(res).to.have.status(200);
     res = await chai
       .request(app)
-      .get('/stores/2')
+      .get(`/stores/${id}`)
       .set('Authorization', jwtToken);
     expect(res.body.position).to.be.deep.equal(position);
   });
@@ -156,9 +157,10 @@ describe('StoreController POST', () => {
 
 describe('StoreController DELETE', () => {
   it('Should delete the 2 store', async () => {
+    const id = stores[1].id;
     let res = await chai
       .request(app)
-      .delete('/stores/2')
+      .delete(`/stores/${id}`)
       .set('Authorization', jwtToken);
     expect(res).to.have.status(200);
     res = await chai
@@ -171,7 +173,7 @@ describe('StoreController DELETE', () => {
   it('Should not find the desired store', async () => {
     const res = await chai
       .request(app)
-      .delete('/stores/1000')
+      .delete('/stores/-1')
       .set('Authorization', jwtToken);
     expect(res).to.have.status(404);
   });

--- a/src/tests/controllers/User.test.ts
+++ b/src/tests/controllers/User.test.ts
@@ -8,12 +8,18 @@ const expect = chai.expect;
 
 describe('UserController should be able to list items', () => {
   it('Should respond with 200', async () => {
-    const res = await chai.request(app).get('/users/').set('Authorization', jwtToken);
+    const res = await chai
+      .request(app)
+      .get('/users/')
+      .set('Authorization', jwtToken);
     expect(res).to.have.status(200);
   });
 
   it('Should list existing users', async () => {
-    const res = await chai.request(app).get('/users/').set('Authorization', jwtToken);
+    const res = await chai
+      .request(app)
+      .get('/users/')
+      .set('Authorization', jwtToken);
     expect(res).to.be.json;
     expect(res.body).to.have.length.above(0);
     expect(res.body).to.have.length(users.length);
@@ -25,10 +31,17 @@ describe('UserController should be able to list items', () => {
 
 describe('UserController update a user', () => {
   it('Should update the first user', async () => {
-    let res = await chai.request(app).patch('/users/50')
-        .send({ firstName: 'toto', lastName: 'lol' }).set('Authorization', jwtToken);
+    const id = users[0].id;
+    let res = await chai
+      .request(app)
+      .patch(`/users/${id}`)
+      .send({ firstName: 'toto', lastName: 'lol' })
+      .set('Authorization', jwtToken);
     expect(res).to.have.status(200);
-    res = await chai.request(app).get('/users/50').set('Authorization', jwtToken);
+    res = await chai
+      .request(app)
+      .get(`/users/${id}`)
+      .set('Authorization', jwtToken);
     expect(res.body.firstName).to.be.equal('toto');
     expect(res.body.lastName).to.be.equal('lol');
   });
@@ -43,23 +56,40 @@ describe('UserController post a user', () => {
       age: tmp.age,
       googleId: tmp.googleId,
     };
-    let res = await chai.request(app).post('/users').send(user).set('Authorization', jwtToken);
+    let res = await chai
+      .request(app)
+      .post('/users')
+      .send(user)
+      .set('Authorization', jwtToken);
     expect(res).to.have.status(201);
-    res = await chai.request(app).get('/users').set('Authorization', jwtToken);
+    res = await chai
+      .request(app)
+      .get('/users')
+      .set('Authorization', jwtToken);
     expect(res.body.length).to.be.equal(users.length + 1);
   });
 });
 
 describe('UserController delete a user', () => {
   it('Should delete a user', async () => {
-    let res = await chai.request(app).delete('/users/40').set('Authorization', jwtToken);
+    const id = users[1].id;
+    let res = await chai
+      .request(app)
+      .delete(`/users/${id}`)
+      .set('Authorization', jwtToken);
     expect(res).to.have.status(200);
-    res = await chai.request(app).get('/users').set('Authorization', jwtToken);
+    res = await chai
+      .request(app)
+      .get('/users')
+      .set('Authorization', jwtToken);
     expect(res.body.length).to.be.equal(users.length - 1);
   });
 
   it('Should not find the desired user', async () => {
-    const res = await chai.request(app).delete('/users/10000').set('Authorization', jwtToken);
+    const res = await chai
+      .request(app)
+      .delete('/users/-1')
+      .set('Authorization', jwtToken);
     expect(res).to.have.status(404);
   });
 });

--- a/src/tests/controllers/Vote.test.ts
+++ b/src/tests/controllers/Vote.test.ts
@@ -1,6 +1,6 @@
 import * as chai from 'chai';
 import chaiHttp = require('chai-http');
-import {app, jwtToken, votes} from '../setup';
+import { app, jwtToken, votes } from '../setup';
 import { Vote } from '@entities/Vote';
 import { getRepository } from 'typeorm';
 
@@ -10,12 +10,18 @@ const expect = chai.expect;
 
 describe('VoteController GET', () => {
   it('Should respond with 200', async () => {
-    const res = await chai.request(app).get('/votes').set('Authorization', jwtToken);
+    const res = await chai
+      .request(app)
+      .get('/votes')
+      .set('Authorization', jwtToken);
     expect(res).to.have.status(200);
   });
 
   it('Should return existing votes', async () => {
-    const res = await chai.request(app).get('/votes').set('Authorization', jwtToken);
+    const res = await chai
+      .request(app)
+      .get('/votes')
+      .set('Authorization', jwtToken);
     expect(res).to.be.json;
     expect(res.body).to.have.length.above(0);
     expect(res.body).to.have.length(votes.length);
@@ -28,14 +34,23 @@ describe('VoteController GET', () => {
 describe('VoteController DELETE Then POST', () => {
   it('Should delete the 1 vote', async () => {
     const id = votes[0].id;
-    let res = await chai.request(app).delete(`/votes/${id}`).set('Authorization', jwtToken);
+    let res = await chai
+      .request(app)
+      .delete(`/votes/${id}`)
+      .set('Authorization', jwtToken);
     expect(res).to.have.status(200);
-    res = await chai.request(app).get('/votes/').set('Authorization', jwtToken);
+    res = await chai
+      .request(app)
+      .get('/votes/')
+      .set('Authorization', jwtToken);
     expect(res.body.length).to.be.equal(votes.length - 1);
   });
 
   it('Should not find the desired vote', async () => {
-    const res = await chai.request(app).delete('/votes/1000').set('Authorization', jwtToken);
+    const res = await chai
+      .request(app)
+      .delete('/votes/-1')
+      .set('Authorization', jwtToken);
     expect(res).to.have.status(404);
   });
 });
@@ -49,9 +64,16 @@ describe('VoteController Post', () => {
     vote.promotion = tmp.promotion;
     vote.upvote = false;
     await getRepository(Vote).remove(tmp);
-    let res = await chai.request(app).post('/votes/').send(vote).set('Authorization', jwtToken);
+    let res = await chai
+      .request(app)
+      .post('/votes/')
+      .send(vote)
+      .set('Authorization', jwtToken);
     expect(res).to.have.status(201);
-    res = await chai.request(app).get('/votes/').set('Authorization', jwtToken);
+    res = await chai
+      .request(app)
+      .get('/votes/')
+      .set('Authorization', jwtToken);
     expect(res.body.length).to.be.equal(votes.length);
   });
 });


### PR DESCRIPTION
instead of using 1 or 2 we are now using list[0].id with list the list gotten in setup.
this prevent using an invalid id by error (which could break the controller/store.test)

also use -1 instead of 1000 for not found id to not cause a problem later if we have more
than 1000 value in a table.